### PR TITLE
This commit fixed a bug when a visitor views the public profile of one user.

### DIFF
--- a/pinax/apps/profiles/views.py
+++ b/pinax/apps/profiles/views.py
@@ -131,8 +131,12 @@ def profile(request, username, template_name="profiles/profile.html", extra_cont
                 "message": ugettext("Let's be friends!"),
             })
     
-    previous_invitations_to = FriendshipInvitation.objects.invitations(to_user=other_user, from_user=request.user)
-    previous_invitations_from = FriendshipInvitation.objects.invitations(to_user=request.user, from_user=other_user)
+    if request.user.is_authenticated():
+        previous_invitations_to = FriendshipInvitation.objects.invitations(to_user=other_user, from_user=request.user)
+        previous_invitations_from = FriendshipInvitation.objects.invitations(to_user=request.user, from_user=other_user)
+    else:
+        previous_invitations_to = []
+        previous_invitations_from = []
     
     return render_to_response(template_name, dict({
         "is_me": is_me,


### PR DESCRIPTION
When we are calling

``` python
previous_invitations_to = FriendshipInvitation.objects.invitations(to_user=other_user, from_user=request.user)
```

`request.user` could be `AnonymousUser` when a guest visitor requests the profile page.

At this time, the query wouldn't work and raise an exception.

The fix checks whether the visitor has logged in or not.
