### PR TITLE
Fix issue with recently committed account code when EMAIL_AUTHENTICATION is True

### DIFF
--- a/pinax/apps/account/forms.py
+++ b/pinax/apps/account/forms.py
@@ -101,7 +101,11 @@ class LoginForm(GroupForm):
     
     def is_valid(self, *args, **kwargs):
         result = super(LoginForm, self).is_valid(*args, **kwargs)
-        user_login_attempt.send(sender=LoginForm, username=self.data["username"], result=result)
+        if EMAIL_AUTHENTICATION:
+            username = self.data["email"]
+        else:
+            username = self.data["username"]
+        user_login_attempt.send(sender=LoginForm, username=username, result=result)
         return result
     
     def login(self, request):


### PR DESCRIPTION
in apps.account.forms the LoginForm.is_valid method that would break if EMAIL_AUTHENTICATION was set to true because it looks for the 'username' key in the form data which does not exist when EMAIL_AUTHENTICATION is set to True.
