### PR TITLE
Simple fix for external base projects

### DIFF
--- a/pinax/core/management/commands/setup_project.py
+++ b/pinax/core/management/commands/setup_project.py
@@ -125,6 +125,7 @@ class Command(BaseCommand):
                     "path: %s" % base
                 )
             else:
+                source = base
                 project_name = os.path.basename(base)
         
         installer = ProjectInstaller(source, destination, project_name, user_project_name)


### PR DESCRIPTION
This pull is more simple than [pull 34](https://github.com/pinax/pinax/pull/34).
Fixes the bug that throws an exception when you pass an external project path as an <code>-b</code> argument for the <code>setup_project</code> task.
