### PR TITLE
Create 'starter_project_list_apps.md'

### DIFF
--- a/docs/apps_list.md
+++ b/docs/apps_list.md
@@ -86,7 +86,7 @@ django-bookmarks provides bookmark management for the Django web framework.
 ## [django-friends](https://github.com/pinax/django-friends)
 django-friends provides friendship, contact, and invitation management for the Django web framework.
 ## [django-flag](https://github.com/pinax/django-flag)
-django-flag provides flagging of inapproprite spam/content.
+django-flag provides flagging of inappropriate spam/content.
 ## [pinax-wiki](https://github.com/pinax/pinax-wiki)
 pinax-wiki lets you easily add a wiki to your Django site.
 

--- a/docs/starter_project_list_apps.md
+++ b/docs/starter_project_list_apps.md
@@ -1,0 +1,40 @@
+
+apps | zero | account | blog  | documents | wiki | team-wiki
+-----|---|--- |--- |--- |--- | --- 
+django | 1.8.4| 1.8.4 | 1.8.4 | 1.8.4 | 1.8.4 | 1.8.4
+django-announcements  | | | | | |
+django-bookmarks | | | | | |
+django-email-confirmation (deprecated) | | | | | |
+django-flag | | | | | |
+django-forms-bootstrap (deprecated?) | | | | | |
+django-friends | | | | | |
+django-mailer | | | | | |
+django-stripe-payments | | | | |
+django-user-accounts | | 1.2 | | 1.2 | 1.2 | 1.2
+django-waitinglist | | | | | |
+metron | | 1.3.5 | | 1.3.5 | 1.3.5 | 1.3.5
+phileo (soon to be pinax-likes) | | | | | |
+pinax-blog | | | 4.2.1 | | |
+pinax-forums | | | | | |
+pinax-lms-activities | | | | | |
+pinax-notifications | | | | | |
+pinax-phone-confirmation | | | | | |
+pinax-points | | | | | |
+pinax-ratings | | | | | |
+pinax-referrals | | | | | |
+pinax-teams | | | | | |
+pinax-testimonials | | | | | |
+pinax-types | | | | | |
+pinax-wiki | | | | | 0.1.3 | 0.1.3
+symposion | | | | | |
+django-bootstrap-form | | | 3.2  | | | 
+django-jsonfield | | 0.9.15 | | 0.9.15 | 0.9.15 | 0.9.15
+django-reversion | | | | | | 1.9.3
+easy-thumbnails | | | | | | 2.2
+Markdown | | | 2.6.2 | | | 
+Pillow | | | 2.9.0 | | | 2.9.0
+pinax-documents | | | | 0.2.0 | | 
+pinax-event-log | | 1.0.0| | 1.0.0 | 1.0.0 | 1.0.0
+pinax-theme-bootstrap | 7.0.0 | 7.0.0 | 7.0.0 | 7.0.0 | 7.0.0 | 7.0.0
+pytz | | | 2015.4 | | | 
+__apps__ | __zero__ | __account__ | __blog__  | __documents__ | __wiki__ | __team-wiki__


### PR DESCRIPTION
A GitHub-flavored Markdown table, drawn from the requirements.txt files of each starter project, showing which apps are included. The first alphabetical list includes apps that appeared in the panix documentation list of apps. The bottom of the table displays apps that weren't included there. A column is included for each starter project. 