### PR TITLE
Adding multiline callable argument alignment preference.

### DIFF
--- a/docs/how_to_contribute.md
+++ b/docs/how_to_contribute.md
@@ -99,6 +99,8 @@ Django's coding style:
 * Tuples should be reserved for positional data structures and not used
   where a list is more appropriate.
 * URL patterns should use the `url()` function rather than a tuple.
+* When callable arguments require multiple lines, place each argument
+  on a new line, indented four spaces as usual.
 
 Here is an example of these rules applied:
 
@@ -145,7 +147,10 @@ Here is an example of these rules applied:
             super(Task, self).save(**kwargs)
 
         def get_absolute_url(self):
-            return reverse("task_detail", kwargs={"task_id": self.pk})
+            return reverse(
+                "task_detail_with_a_super_long_url_name",
+                kwargs={"task_id": self.pk}
+            )
 
         # custom methods
 


### PR DESCRIPTION
As per @brosner commenting on this code snippet:

```
    relationship_url = reverse("product-category-relationship-detail",
                               kwargs=dict(pk=product.pk))
```
> I really don't like lining up arguments to the function call line like this. I personally just find it ugly. I don't know if we state anywhere this particular preference, but the typical style we use at Eldarion is:
> 
> ```
> relationship_url = reverse(
>    "product-category-relationship-detail",
>    kwargs=dict(pk=product.pk)
> )
```