### PR TITLE
Update the MkDocs Configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,32 +1,32 @@
 site_name: Pinax Documentation
 
 pages:
-    - "index.md"
-
-    - ["what_is_pinax.md", "Introduction", "What is Pinax?"]
-    - ["quick_start.md", "Introduction", "Quick Start"]
-    - ["history.md", "Introduction", "History"]
-    - ["faq.md", "Introduction", "FAQs"]
-
-    - ["pinax_starter_projects.md", "Starter Projects", "Pinax Starter Projects"]
-    - ["starter_project_list.md", "Starter Projects", "List of Starter Projects"]
-    - ["pinax_theme_bootstrap.md", "Starter Projects", "Pinax Theme Bootstrap"]
-
-    - ["apps_list.md", "Apps", "List of Apps"]
-
-    - ["how-tos/ldap.md", "How Tos", "LDAP Integration"]
-    - ["how-tos/deploy-to-heroku.md", "How Tos", "Deploying to Heroku"]
-    - ["how-tos/release-starter-project.md", "How Tos", "Releasing a Starter Project"]
-
-    - ["how_to_contribute.md", "Development", "How to Contribute"]
-    - ["ways_to_contribute.md", "Development", "Ways to Contribute"]
-    - ["release_process.md", "Development", "Release Process"]
-    - ["code_of_conduct.md", "Development", "Code of Conduct"]
-  
-    - ["tutorials.md", "Tutorials", "Tutorials"]
-
-    - ["in_the_wild.md", "In the Wild", "In the Wild"]
-
-    - ["companies_working_with_pinax.md", "Companies Working with Pinax", "Companies Working with Pinax"]
+  - index.md
+  - Introduction:
+    - 'What is Pinax?': what_is_pinax.md
+    - Quick Start: quick_start.md
+    - History: history.md
+    - FAQs: faq.md
+  - Starter Projects:
+    - Pinax Starter Projects: pinax_starter_projects.md
+    - List of Starter Projects: starter_project_list.md
+    - Pinax Theme Bootstrap: pinax_theme_bootstrap.md
+  - Apps:
+    - List of Apps: apps_list.md
+  - How Tos:
+    - LDAP Integration: how-tos/ldap.md
+    - Deploying to Heroku: how-tos/deploy-to-heroku.md
+    - Releasing a Starter Project: how-tos/release-starter-project.md
+  - Development:
+    - How to Contribute: how_to_contribute.md
+    - Ways to Contribute: ways_to_contribute.md
+    - Release Process: release_process.md
+    - Code of Conduct: code_of_conduct.md
+  - Tutorials:
+    - Tutorials: tutorials.md
+  - In the Wild:
+    - In the Wild: in_the_wild.md
+  - Companies Working with Pinax:
+    - Companies Working with Pinax: companies_working_with_pinax.md
 
 theme: readthedocs


### PR DESCRIPTION
This new structure for MkDocs pages configuration was released with MkDocs
version 0.13 (release 2015-05-27). It is a much cleaner and clearer way to
represent your page tree (and allows further nesting beyond a top level and
second level).